### PR TITLE
Fix missing support for Fixnum::positive?

### DIFF
--- a/lib/puppet/feature/facter_cacheable.rb
+++ b/lib/puppet/feature/facter_cacheable.rb
@@ -16,7 +16,7 @@ require 'facter'
 Puppet.features.add(:facter_cacheable) do
   require 'time'
   require 'yaml'
-  if Puppet::Util::Package.versioncmp(Puppet.version, '5.0.0').positive? || Puppet.features.external_facts?
+  if Puppet::Util::Package.versioncmp(Puppet.version, '5.0.0') > 0 || Puppet.features.external_facts?
     # use external location
     Facter.search_external_path.each do |dir|
       Puppet::FileSystem.exist?(dir)


### PR DESCRIPTION
Puppet 4.10.12 runs Ruby 2.1 and lacks this property.

    Failed to load feature test for facter_cacheable: undefined method `positive?' for -1:Fixnum

Found on CentOS 7 running puppet version 4.10.12 via package `puppet-agent-1.10.14-1`.