### PR TITLE
replace legacy facts

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,7 @@
 #  Warn on unsupported operatingsytems
 #
 class facter_cacheable {
-  if $::osfamily == 'Microsoft' {
-    fail("${::operatingsystem} is not supported.")
+  if $facts['os']['family'] == 'Microsoft' {
+    fail("${facts['os']['name']} is not supported.")
   }
 }

--- a/spec/classes/facter_cacheable_spec.rb
+++ b/spec/classes/facter_cacheable_spec.rb
@@ -9,7 +9,7 @@ describe 'facter_cacheable' do
         let(:params) { {} }
         let(:facts) do
           {
-            osfamily: osfamily,
+            os: {family: osfamily},
           }
         end
 
@@ -23,8 +23,7 @@ describe 'facter_cacheable' do
     describe 'facter_cacheable class without any parameters on Windows' do
       let(:facts) do
         {
-          osfamily: 'Microsoft',
-          operatingsystem: 'Windows',
+          os: {family: 'Microsoft', name: 'Windows'},
         }
       end
       let(:params) { {} }


### PR DESCRIPTION
Puppet 8 agents default to not sending legacy facts